### PR TITLE
Fix code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/src/helpers/linkUtils.js
+++ b/src/helpers/linkUtils.js
@@ -13,7 +13,7 @@ function extractLinks(content) {
           .slice(2, -2)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),
@@ -23,7 +23,7 @@ function extractLinks(content) {
           .slice(6, -1)
           .split("|")[0]
           .replace(/.(md|markdown)\s?$/i, "")
-          .replace("\\", "")
+          .replace(/\\/g, "")
           .trim()
           .split("#")[0]
     ),


### PR DESCRIPTION
Fixes [https://github.com/ATG-Anubis/notes-pbv/security/code-scanning/4](https://github.com/ATG-Anubis/notes-pbv/security/code-scanning/4)

To fix the problem, we need to ensure that all occurrences of the backslash character are removed from the extracted links. This can be achieved by using a regular expression with the `g` flag in the `replace` method. This change will ensure that all backslashes are replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
