### PR TITLE
Fix code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -365,7 +365,7 @@ module.exports = function (eleventyConfig) {
           function (metaInfoMatch, callout, metaData, collapse, title) {
             isCollapsable = Boolean(collapse);
             isCollapsed = collapse === "-";
-            const titleText = title.replace(/(<\/{0,1}\w+>)/, "")
+            const titleText = title.replace(/<\/?\w+>/g, "")
               ? title
               : `${callout.charAt(0).toUpperCase()}${callout
                 .substring(1)


### PR DESCRIPTION
Fixes [https://github.com/ATG-Anubis/notes-pbv/security/code-scanning/1](https://github.com/ATG-Anubis/notes-pbv/security/code-scanning/1)

To fix the problem, we need to ensure that all occurrences of HTML tags in the `title` string are removed, not just the first one. This can be achieved by using a global regular expression that matches all instances of the pattern. Additionally, we should consider using a well-tested sanitization library to handle this more effectively.

The best way to fix this without changing existing functionality is to modify the regular expression to include the global flag (`g`). This ensures that all matches are replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
